### PR TITLE
Add RoutingOptions to payment requests

### DIFF
--- a/src/request/CreateDepositPaymentRequest.ts
+++ b/src/request/CreateDepositPaymentRequest.ts
@@ -1,6 +1,7 @@
 import Currency from '../model/Currency';
 
 import {Card} from './dto/Card';
+import RoutingOptions from './dto/RoutingOptions';
 
 type CreateDepositPaymentRequest = {
   buyerMemberId: number;
@@ -11,6 +12,7 @@ type CreateDepositPaymentRequest = {
   posAlias?: string;
   clientIp?: string;
   card: Card;
+  routingOptions?: RoutingOptions;
 };
 
 export default CreateDepositPaymentRequest;

--- a/src/request/CreatePaymentRequest.ts
+++ b/src/request/CreatePaymentRequest.ts
@@ -6,6 +6,7 @@ import PaymentPhase from '../model/PaymentPhase';
 import {Card} from './dto/Card';
 import FraudCheckParameters from './dto/FraudCheckParameters';
 import PaymentItem from './dto/PaymentItem';
+import RoutingOptions from './dto/RoutingOptions';
 
 type CreatePaymentRequest = {
   price: number;
@@ -23,6 +24,7 @@ type CreatePaymentRequest = {
   bankOrderId?: string;
   card?: Card;
   posAlias?: string;
+  routingOptions?: RoutingOptions;
   fraudParams?: FraudCheckParameters;
   items: PaymentItem[];
   additionalParams?: Record<string, unknown>;

--- a/src/request/InitCheckoutPaymentRequest.ts
+++ b/src/request/InitCheckoutPaymentRequest.ts
@@ -6,6 +6,7 @@ import PaymentPhase from '../model/PaymentPhase';
 import CustomInstallment from './dto/CustomInstallment';
 import FraudCheckParameters from './dto/FraudCheckParameters';
 import PaymentItem from './dto/PaymentItem';
+import RoutingOptions from './dto/RoutingOptions';
 
 type InitCheckoutPaymentRequest = {
   price: number;
@@ -36,6 +37,7 @@ type InitCheckoutPaymentRequest = {
   ttl?: number;
   customInstallments?: CustomInstallment[];
   items?: PaymentItem[];
+  routingOptions?: RoutingOptions;
   fraudParams?: FraudCheckParameters;
   additionalParams?: Record<string, unknown>;
   cardBrandInstallments?: Map<string, CustomInstallment[]>;

--- a/src/request/dto/RoutingOptions.ts
+++ b/src/request/dto/RoutingOptions.ts
@@ -1,0 +1,12 @@
+export enum OrderingRule {
+  ON_US = 'ON_US',
+  LOW_COMMISSION_RATE = 'LOW_COMMISSION_RATE',
+  IN_ORDER = 'IN_ORDER'
+}
+
+type RoutingOptions = {
+  orderingRule?: OrderingRule;
+  posAliases?: string[];
+};
+
+export default RoutingOptions;


### PR DESCRIPTION
## Summary
Add RoutingOptions type to payment requests to allow clients to specify routing preferences.

## Changes
- Add `RoutingOptions` type with `OrderingRule` enum (ON_US, LOW_COMMISSION_RATE, IN_ORDER) and `posAliases` field
- Add `routingOptions` field to:
  - `CreatePaymentRequest`
  - `CreateDepositPaymentRequest`
  - `InitThreeDSPaymentRequest` (extends CreatePaymentRequest)
  - `InitCheckoutPaymentRequest`

## Technical Details
- `OrderingRule` enum values: ON_US, LOW_COMMISSION_RATE, IN_ORDER
- `posAliases`: Optional array of POS aliases for routing configuration
- All fields are optional to maintain backward compatibility

## Test Plan
- [ ] Verify TypeScript compilation
- [ ] Test payment request creation with routingOptions
- [ ] Test backward compatibility (requests without routingOptions)
- [ ] Verify serialization/deserialization